### PR TITLE
chore: crowdin.yml use %locale% for Fastlane

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,12 +4,7 @@ files:
     translate_content: 0
     translate_attributes: 0
 
-  - source: /fastlane/metadata/android/en-US/full_description.txt
-    translation: /fastlane/metadata/android/%two_letters_code%/full_description.txt
-    translate_content: 1
-    translate_attributes: 0
-
-  - source: /fastlane/metadata/android/en-US/short_description.txt
-    translation: /fastlane/metadata/android/%two_letters_code%/short_description.txt
+  - source: /fastlane/metadata/android/en-US/*.txt
+    translation: /fastlane/metadata/android/%locale%/%original_file_name%
     translate_content: 1
     translate_attributes: 0


### PR DESCRIPTION
The `%two_letters_code%` won't have a region part so you can't have separate `pt-PT` and `pt-BR` and others.

[Crowdin Configuration File](https://support.crowdin.com/developer/configuration-file/) proposes to use the `%locale%` instead.

Additionally we can use the `%original_file_name%` to simplify mapping. This will also allow to translate changelogs.